### PR TITLE
Update RoomPoolManager callback signatures

### DIFF
--- a/Assets/Script/RoomPoolManager.cs
+++ b/Assets/Script/RoomPoolManager.cs
@@ -319,7 +319,7 @@ public class RoomPoolManager : MonoBehaviour, INetworkRunnerCallbacks
     {
     }
 
-    public void OnDisconnectedFromServer(NetworkRunner runner)
+    public void OnDisconnectedFromServer(NetworkRunner runner, NetDisconnectReason reason)
     {
     }
 
@@ -355,7 +355,11 @@ public class RoomPoolManager : MonoBehaviour, INetworkRunnerCallbacks
     {
     }
 
-    public void OnReliableDataReceived(NetworkRunner runner, PlayerRef player, ArraySegment<byte> data)
+    public void OnReliableDataReceived(NetworkRunner runner, PlayerRef player, ReliableKey key, ArraySegment<byte> data)
+    {
+    }
+
+    public void OnReliableDataProgress(NetworkRunner runner, PlayerRef player, ReliableKey key, float progress)
     {
     }
 


### PR DESCRIPTION
## Summary
- align RoomPoolManager's OnDisconnectedFromServer callback signature with Fusion's NetDisconnectReason parameter
- include the ReliableKey parameter in OnReliableDataReceived and add an empty OnReliableDataProgress stub

## Testing
- `dotnet build ServerGame.sln` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0cde02b883328bf8d99e684dd8cc