### PR TITLE
Fix RoomPoolManager connect refusal overload

### DIFF
--- a/Assets/Script/RoomPoolManager.cs
+++ b/Assets/Script/RoomPoolManager.cs
@@ -328,7 +328,7 @@ public class RoomPoolManager : MonoBehaviour, INetworkRunnerCallbacks
         if (_currentOnlinePlayers >= _maxConcurrentPlayers)
         {
             Debug.LogError("quá tải server");
-            request.Refuse(NetConnectFailedReason.ServerFull);
+            request.Refuse();
             return;
         }
 


### PR DESCRIPTION
## Summary
- replace the invalid OnConnectRequest refusal overload with the parameterless version supported by Fusion

## Testing
- `dotnet build ServerGame.sln` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0db099c88332b7e667ede497ad73