### PR TITLE
Add server startup dashboard log with room statistics

### DIFF
--- a/Assets/Script/Server/ServerLauncher.cs
+++ b/Assets/Script/Server/ServerLauncher.cs
@@ -61,6 +61,19 @@ public class ServerLauncher : MonoBehaviour
 
         yield return _roomPoolManager.InitialisePool(customSettings, basePort, roomPrefix);
 
+        var stats = _roomPoolManager.GetStatisticsSnapshot();
+        var statusLines = new[]
+        {
+            "🎮🔥 SERVER GAME BAN CULI DASHBOARD 🔥🎮",
+            "==============================",
+            $"📡 Photon Region : {(!string.IsNullOrWhiteSpace(stats.PhotonRegion) ? stats.PhotonRegion : "n/a")}",
+            $"👥 Online Players: {stats.TotalOnlinePlayers}",
+            $"🏠 Total Rooms    : {stats.TotalRooms}",
+            $"🎯 Rooms Occupied : {stats.OccupiedRooms}",
+            $"🚀 Rooms At Cap   : {stats.FullRooms}",
+        };
+
+        Debug.Log(string.Join(Environment.NewLine, statusLines));
         Debug.Log("✅ Dedicated server room pool initialised successfully.");
     }
 


### PR DESCRIPTION
## Summary
- add a RoomPoolStatistics DTO and accessor that captures Photon region, online player count, and room occupancy data
- emit a branded multi-line dashboard log with the latest pool statistics once the server pool finishes initialising

## Testing
- dotnet build ServerGame.sln *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df3195656c8332998a9f2b9d6829be