### PR TITLE
Use ServerConfig asset for public IP configuration

### DIFF
--- a/Assets/Scenes/ServerScene.unity
+++ b/Assets/Scenes/ServerScene.unity
@@ -151,6 +151,7 @@ MonoBehaviour:
   _targetEmptyRooms: 3
   _maxPlayersPerRoom: 3
   _idleShutdownSeconds: 180
+  _serverConfig: {fileID: 11400000, guid: 8d6e29d65bbadc94f8282a889c88f3f5, type: 2}
   _maxConcurrentPlayers: 18
   _quickMatchClientPrefab: {fileID: 0}
   _quickMatchPlayerControllerPrefab:

--- a/Assets/Script/Server/ServerConfig.asset
+++ b/Assets/Script/Server/ServerConfig.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f1a9f6d1cc63d848a19fb2394d8cfef, type: 3}
+  m_Name: ServerConfig
+  m_EditorClassIdentifier:
+  _publicIpAddress: 103.12.77.207

--- a/Assets/Script/Server/ServerConfig.asset.meta
+++ b/Assets/Script/Server/ServerConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8d6e29d65bbadc94f8282a889c88f3f5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Script/Server/ServerConfig.cs
+++ b/Assets/Script/Server/ServerConfig.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Server/Server Config", fileName = "ServerConfig")]
+public class ServerConfig : ScriptableObject
+{
+    [SerializeField]
+    private string _publicIpAddress = string.Empty;
+
+    public string PublicIpAddress => _publicIpAddress;
+}

--- a/Assets/Script/Server/ServerConfig.cs.meta
+++ b/Assets/Script/Server/ServerConfig.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6f1a9f6d1cc63d848a19fb2394d8cfef


### PR DESCRIPTION
## Summary
- add a ServerConfig ScriptableObject for storing the server public IP address
- resolve and validate the configured public IP during room pool initialisation and use it for new rooms
- assign the new ServerConfig asset with the VPS IP on the server scene

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68df39ae5e3c8332a4df51ec7c416c27