### PR TITLE
Track room indices for quick match services

### DIFF
--- a/Assets/Script/Server/QuickMatchServerCallbacks.cs
+++ b/Assets/Script/Server/QuickMatchServerCallbacks.cs
@@ -10,19 +10,24 @@ public class QuickMatchServerCallbacks : MonoBehaviour, INetworkRunnerCallbacks
     private NetworkObject? _quickMatchClientInstance;
 
     [SerializeField]
+    private int _roomIndex = -1;
+
+    [SerializeField]
     private NetworkPrefabRef _playerControllerPrefab;
 
     private readonly Dictionary<PlayerRef, NetworkObject> _playerControllers = new();
 
     public NetworkObject? QuickMatchClientInstance => _quickMatchClientInstance;
+    public int RoomIndex => _roomIndex;
 
     public void SetPlayerControllerPrefab(NetworkPrefabRef prefab)
     {
         _playerControllerPrefab = prefab;
     }
 
-    public void Initialise(NetworkObject? instance)
+    public void Initialise(int roomIndex, NetworkObject? instance)
     {
+        _roomIndex = roomIndex;
         _quickMatchClientInstance = instance;
     }
 


### PR DESCRIPTION
## Summary
- add a monotonically increasing room index to room entries when creating runners
- rename spawned quick match service objects with the indexed room naming convention
- pass the room index through quick match callbacks for future consumers

## Testing
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68df3cd762188332b811ab91dd00134e