### PR TITLE
Parent quick match controllers under room runners

### DIFF
--- a/Assets/Script/Server/RoomPoolManager.cs
+++ b/Assets/Script/Server/RoomPoolManager.cs
@@ -362,7 +362,7 @@ public class RoomPoolManager : MonoBehaviour, INetworkRunnerCallbacks
             _rooms[runner] = entry;
             if (quickMatchCallbacks != null)
             {
-                quickMatchCallbacks.Initialise(entry.Index, quickMatchInstance);
+                quickMatchCallbacks.Initialise(entry.Index, entry.Name, quickMatchInstance);
                 _quickMatchServerCallbacks[runner] = quickMatchCallbacks;
             }
 


### PR DESCRIPTION
## Summary
- cache the room name/transform when initialising `QuickMatchServerCallbacks`
- parent newly spawned player controllers under the room runner and rename them to `<label>_Input`
- derive a player display label from available metadata before registering the controller

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df3dc43cf8833286983d7687d6550c