### PR TITLE
Ensure server runners use default object provider

### DIFF
--- a/Assets/Script/Server/RoomPoolManager.cs
+++ b/Assets/Script/Server/RoomPoolManager.cs
@@ -303,6 +303,12 @@ public class RoomPoolManager : MonoBehaviour, INetworkRunnerCallbacks
             Debug.LogWarning("Quick match client prefab has not been assigned for server runners.");
         }
 
+        var objectProvider = runner.GetComponent<INetworkObjectProvider>();
+        if (objectProvider == null)
+        {
+            objectProvider = go.AddComponent<NetworkObjectProviderDefault>();
+        }
+
         var args = new StartGameArgs
         {
             GameMode = GameMode.Server,
@@ -314,7 +320,8 @@ public class RoomPoolManager : MonoBehaviour, INetworkRunnerCallbacks
             //CustomPublicAddress = NetAddress.CreateFromIpPort(_resolvedPublicIpAddress, port),
             SceneManager = sceneManager,
             PlayerCount = _maxPlayersPerRoom,
-            CustomPhotonAppSettings = _customPhotonSettings
+            CustomPhotonAppSettings = _customPhotonSettings,
+            ObjectProvider = objectProvider
         };
 
         var startTask = runner.StartGame(args);


### PR DESCRIPTION
## Summary
- ensure dedicated server runners include an `INetworkObjectProvider`, adding `NetworkObjectProviderDefault` when one is missing
- pass the resolved object provider into `StartGameArgs` so room startup mirrors `FusionBootstrap`

## Testing
- dotnet build ServerGame.sln *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df627e8b908332a4fd02015d1b3364