### PR TITLE
Ensure Fusion app settings instance when starting rooms

### DIFF
--- a/Assets/Script/Server/RoomPoolManager.cs
+++ b/Assets/Script/Server/RoomPoolManager.cs
@@ -320,7 +320,7 @@ public class RoomPoolManager : MonoBehaviour, INetworkRunnerCallbacks
             //CustomPublicAddress = NetAddress.CreateFromIpPort(_resolvedPublicIpAddress, port),
             SceneManager = sceneManager,
             PlayerCount = _maxPlayersPerRoom,
-            CustomPhotonAppSettings = _customPhotonSettings,
+            CustomPhotonAppSettings = _customPhotonSettings as FusionAppSettings ?? new FusionAppSettings { AppSettings = _customPhotonSettings },
             ObjectProvider = objectProvider
         };
 


### PR DESCRIPTION
## Summary
- ensure room creation passes a FusionAppSettings instance to CustomPhotonAppSettings by converting stored AppSettings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df640f156083329479396230dc200e