### PR TITLE
Fix quick match runner parenting to stay at scene root

### DIFF
--- a/Assets/Script/Server/RoomPoolManager.cs
+++ b/Assets/Script/Server/RoomPoolManager.cs
@@ -367,7 +367,7 @@ public class RoomPoolManager : MonoBehaviour, INetworkRunnerCallbacks
             if (quickMatchInstance != null)
             {
                 quickMatchInstance.gameObject.name = $"Room_{entry.Index}_{roomName}";
-                quickMatchInstance.transform.SetParent(go.transform, false);
+                quickMatchInstance.transform.SetParent(null);
             }
 
             _rooms[runner] = entry;


### PR DESCRIPTION
## Summary
- stop parenting quick match runner instances to the room runner GameObject so they remain at the scene root
- confirm existing shutdown code still despawns quick match instances directly from the stored references

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfb7cccd3883329c490ec08260f749