### PR TITLE
Ensure quick match runner prefab persists across scenes

### DIFF
--- a/Assets/Script/Server/RoomPoolManager.cs
+++ b/Assets/Script/Server/RoomPoolManager.cs
@@ -346,6 +346,7 @@ public class RoomPoolManager : MonoBehaviour, INetworkRunnerCallbacks
                 try
                 {
                     quickMatchInstance = runner.Spawn(_quickMatchClientPrefab, Vector3.zero, Quaternion.identity);
+                    DontDestroyOnLoad(quickMatchInstance.gameObject);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Summary
- ensure quick match quick-match client instances are marked as non-destructible when rooms spawn

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfbc5c8bb8833296034952925a02a3