### PR TITLE
Adjust room scene parenting for quick match clients

### DIFF
--- a/Assets/Script/Server/RoomPoolManager.cs
+++ b/Assets/Script/Server/RoomPoolManager.cs
@@ -432,7 +432,7 @@ public class RoomPoolManager : MonoBehaviour, INetworkRunnerCallbacks
                 if (quickMatchInstance != null)
                 {
                     quickMatchInstance.gameObject.name = $"Room_{entry.Index}_{roomName}";
-                    AttachNetworkObjectToRoomScene(quickMatchInstance, entry, fallbackToDontDestroyOnLoad: true);
+                    AttachNetworkObjectToRoomScene(quickMatchInstance, entry, fallbackToDontDestroyOnLoad: true, parentUnderRoomRoot: false);
                 }
             }
 
@@ -673,7 +673,7 @@ public class RoomPoolManager : MonoBehaviour, INetworkRunnerCallbacks
         Debug.Log($"🌐 Loaded network scene '{_networkSceneName}' for room '{entry.Name}'.");
     }
 
-    private void AttachNetworkObjectToRoomScene(NetworkObject networkObject, RoomEntry entry, bool fallbackToDontDestroyOnLoad)
+    private void AttachNetworkObjectToRoomScene(NetworkObject networkObject, RoomEntry entry, bool fallbackToDontDestroyOnLoad, bool parentUnderRoomRoot = true)
     {
         if (networkObject == null)
         {
@@ -694,7 +694,7 @@ public class RoomPoolManager : MonoBehaviour, INetworkRunnerCallbacks
                 Debug.LogWarning($"⚠️ Unable to move '{go.name}' into scene '{targetScene.name}': {ex.Message}");
             }
 
-            if (entry.NetworkSceneRoot != null)
+            if (parentUnderRoomRoot && entry.NetworkSceneRoot != null)
             {
                 go.transform.SetParent(entry.NetworkSceneRoot, false);
             }


### PR DESCRIPTION
## Summary
- add a parentUnderRoomRoot toggle when attaching network objects to the room scene
- keep quick match client instances at the scene root when loading them for a room

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0cb4c3ec08332b931c1b5739b6d03