### PR TITLE
Disable network scene setup coroutine

### DIFF
--- a/Assets/Script/Server/RoomPoolManager.cs
+++ b/Assets/Script/Server/RoomPoolManager.cs
@@ -373,7 +373,7 @@ public class RoomPoolManager : MonoBehaviour, INetworkRunnerCallbacks
                 NetworkSceneRoot = null
             };
 
-            yield return SetupNetworkSceneCoroutine(entry, runner, sceneManager);
+            /* yield return SetupNetworkSceneCoroutine(entry, runner, sceneManager); */
 
             var hasValidSceneRef = entry.NetworkSceneRef.IsValid;
             var hasValidScene = entry.NetworkScene.IsValid();
@@ -463,7 +463,7 @@ public class RoomPoolManager : MonoBehaviour, INetworkRunnerCallbacks
         }
     }
 
-    private IEnumerator SetupNetworkSceneCoroutine(RoomEntry entry, NetworkRunner runner, NetworkSceneManagerDefault sceneManager)
+    /* private IEnumerator SetupNetworkSceneCoroutine(RoomEntry entry, NetworkRunner runner, NetworkSceneManagerDefault sceneManager)
     {
         entry.NetworkSceneRef = default;
         entry.NetworkScene = default;
@@ -673,7 +673,7 @@ public class RoomPoolManager : MonoBehaviour, INetworkRunnerCallbacks
         }
 
         Debug.Log($"🌐 Loaded network scene '{_networkSceneName}' for room '{entry.Name}'.");
-    }
+    } */
 
     private void AttachNetworkObjectToRoomScene(NetworkObject networkObject, RoomEntry entry, bool fallbackToDontDestroyOnLoad, bool parentUnderRoomRoot = true)
     {


### PR DESCRIPTION
## Summary
- comment out the `SetupNetworkSceneCoroutine` call during room creation to prevent executing the network scene setup
- wrap the `SetupNetworkSceneCoroutine` implementation in a block comment so it is excluded without deleting the code

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2a152e03c83329c6258c5e937a7ac